### PR TITLE
Do not pick reviewers that have been picked in another group

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,13 @@ module.exports = app => {
         let possibleReviewers = group.possible_reviewers.map(x => x.toLowerCase())
         let numberOfPicks = group.number_of_picks
 
+        // Remove PR owner from the array of possible reviewers
         let index = possibleReviewers.indexOf(owner)
         if (index > -1) {
           possibleReviewers.splice(index, 1)
         }
 
+        // Remove existing reviewers from the array of possible reviewers
         for (let i = 0; i < existingReviewers.data.users.length; i++) {
           index = possibleReviewers.indexOf(existingReviewers.data.users[i].login.toLowerCase())
           if (index > -1) {
@@ -97,7 +99,16 @@ module.exports = app => {
           }
         }
 
-        for (let i = 0; i < numberOfPicks; i++) {
+        // Remove reviewers already picked from the array of possible reviewers
+        for (let i = 0; i < pickedReviewers.length; i++) {
+          index = possibleReviewers.indexOf(pickedReviewers[i])
+          if (index > -1) {
+            possibleReviewers.splice(index, 1)
+          }
+        }
+
+        // Pick reviewers at random until you have enough, or run out of possible reviewers
+        for (let i = 0; i < numberOfPicks && possibleReviewers.length > 0; i++) {
           let pickedReviewer = possibleReviewers[Math.floor(Math.random() * possibleReviewers.length)]
           index = possibleReviewers.indexOf(pickedReviewer)
           possibleReviewers.splice(index, 1)


### PR DESCRIPTION
• Adds a additional loop which removes any reviewers that may have been picked in previous groups from the array of `possibleReviewers` before making the random selection of reviewers.

• Also adds an additional condition to the "picking reviewers" loop to end the loop if there are no reviewers left in the array of `possibleReviewers`. This will prevent null values from being pushed into the array of `pickedReviewers` if find-reviewers runs out of reviewers in a group to pick.